### PR TITLE
Fix typing error with ts-node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "moment": "^2.29.1",
     "soltypes": "^1.3.3",
     "ts-command-line-args": "^1.8.0",
-    "ts-node": "^10.1.0",
+    "ts-node": "^10.8.1",
     "tsconfig-paths": "^3.10.1",
     "typescript": "^4.3.5",
     "yalc": "^1.0.0-pre.53"


### PR DESCRIPTION
Error message - Debug Failure. False Expression: Non-string value passed to ts.resolveTypeReferenceDirective, likely by a wrapping package working with an outdated resolveTypeReferenceDirectives signature.

Update ts-node from 10.2.1 to 10.8.1

# Summary
Fix a library dependency which causes a typing error when imx-examples first run


# Why the changes
ts-node version seems to have broken but now fixed with new version


# Things worth calling out
"should be trivial" but I'm not an expert :D