### PR TITLE
Fix .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,7 +5,7 @@ ALCHEMY_API_KEY=
 # ropsten/mainnet etc.
 ETH_NETWORK=goerli
 # IMX API endpoint
-PUBLIC_API_URL=https://api.sandbox.x.immutable.com/v1
+PUBLIC_API_URL=https://api.sandbox.x.immutable.com/v1/
 STARK_CONTRACT_ADDRESS=0x7917eDb51ecD6CdB3F9854c3cc593F33de10c623
 REGISTRATION_ADDRESS=0x1C97Ada273C9A52253f463042f29117090Cd7D83
 GAS_LIMIT=7000000


### PR DESCRIPTION
# Summary
Corrects URL of Immutable's API in .env.example.


# Why the changes
When doing [this guide](https://docs.x.immutable.com/docs/zero-to-hero-nft-minting/#step-3-obtain-goerlieth), on step 12 I would get this because of incorrect URL:
```
REQUEST:
 POST https://api.sandbox.x.immutable.com/v1projects
RESPONSE:
 404 Not Found
```