### PR TITLE
Update bulk-mint.ts

### DIFF
--- a/src/bulk-mint.ts
+++ b/src/bulk-mint.ts
@@ -58,9 +58,9 @@ const waitForTransaction = async (promise: Promise<string>) => {
   });
 
   const accounts = await minter.getUser({
-    user: minter.address
+    user: minter.address,
   });
-  if(accounts.accounts.length === 0) {
+  if (accounts.accounts.length === 0) {
     log.info(component, 'MINTER REGISTRATION');
     const registerImxResult = await minter.registerImx({
       etherKey: minter.address.toLowerCase(),

--- a/src/bulk-mint.ts
+++ b/src/bulk-mint.ts
@@ -57,17 +57,22 @@ const waitForTransaction = async (promise: Promise<string>) => {
     signer: new Wallet(env.privateKey1).connect(provider),
   });
 
-  log.info(component, 'MINTER REGISTRATION');
-  const registerImxResult = await minter.registerImx({
-    etherKey: minter.address.toLowerCase(),
-    starkPublicKey: minter.starkPublicKey,
+  const accounts = await minter.getUser({
+    user: minter.address
   });
+  if(accounts.accounts.length === 0) {
+    log.info(component, 'MINTER REGISTRATION');
+    const registerImxResult = await minter.registerImx({
+      etherKey: minter.address.toLowerCase(),
+      starkPublicKey: minter.starkPublicKey,
+    });
 
-  if (registerImxResult.tx_hash === '') {
-    log.info(component, 'Minter registered, continuing...');
-  } else {
-    log.info(component, 'Waiting for minter registration...');
-    await waitForTransaction(Promise.resolve(registerImxResult.tx_hash));
+    if (registerImxResult.tx_hash === '') {
+      log.info(component, 'Minter registered, continuing...');
+    } else {
+      log.info(component, 'Waiting for minter registration...');
+      await waitForTransaction(Promise.resolve(registerImxResult.tx_hash));
+    }
   }
 
   log.info(component, `OFF-CHAIN MINT ${number} NFTS`);


### PR DESCRIPTION
fix for account_ether_key_already_registered error

# Summary
There was a sdk update that created a breaking error when users were already registered in the bulk-mint.ts. A check was added to make sure that the user registration logic only happens when the user hasn't registered previously and skips if they were already registered.
![image](https://github.com/immutable/imx-examples/assets/108304844/860558b3-f1b2-443a-bc93-a5e3f06ec7b3)


# Why the changes
This error is causing friction/confusion for onboarding users with the [zero-to hero minting tutorial in step 16](https://docs.immutable.com/docs/x/zero-to-hero-nft-minting/#step-16-mint-nft).


# Things worth calling out
N/a